### PR TITLE
Add sync transform if w/ only explicit plugins

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -44,20 +44,43 @@ export default function remarkTextr(options) {
   const settings = options || emptyOptions
   const plugins = settings.plugins || []
   const textrOptions = settings.options || {}
-  const promise = Promise.all(
-    plugins.map(async function (fn) {
-      if (typeof fn === 'string') {
-        // Assume plugin at default.
-        /** @type {{default: TextrPlugin}} */
-        const mod = await import(fn)
-        return mod.default
-      }
 
-      return fn
-    })
-  ).then(function (list) {
-    return textr(textrOptions).use(...list)
-  })
+  const noNeedPromise =
+    plugins.filter((plugin) => typeof plugin === 'string').length === 0
+
+  const promise = noNeedPromise
+    ? textr(textrOptions).use(...plugins)
+    : Promise.all(
+        plugins.map(async function (fn) {
+          if (typeof fn === 'string') {
+            // Assume plugin at default.
+            /** @type {{default: TextrPlugin}} */
+            const mod = await import(fn)
+            return mod.default
+          }
+
+          return fn
+        })
+      ).then(function (list) {
+        return textr(textrOptions).use(...list)
+      })
+
+  if (!(promise instanceof Promise)) {
+    /**
+     * Transform.
+     *
+     * @param {Root} tree
+     *   Tree.
+     * @returns {undefined}
+     *   Nothing.
+     */
+    return function (tree) {
+      const typography = promise
+      visit(tree, 'text', function (node) {
+        node.value = typography.exec(node.value)
+      })
+    }
+  }
 
   /**
    * Transform.

--- a/lib/index.js
+++ b/lib/index.js
@@ -45,29 +45,13 @@ export default function remarkTextr(options) {
   const plugins = settings.plugins || []
   const textrOptions = settings.options || {}
 
-  const noNeedPromise =
-    plugins.filter((plugin) => typeof plugin === 'string').length === 0
+  const needsPromise = plugins.some((plugin) => typeof plugin === 'string')
 
-  const promise = noNeedPromise
-    ? textr(textrOptions).use(...plugins)
-    : Promise.all(
-        plugins.map(async function (fn) {
-          if (typeof fn === 'string') {
-            // Assume plugin at default.
-            /** @type {{default: TextrPlugin}} */
-            const mod = await import(fn)
-            return mod.default
-          }
+  if (!needsPromise) {
+    const typography = textr(textrOptions).use(...plugins)
 
-          return fn
-        })
-      ).then(function (list) {
-        return textr(textrOptions).use(...list)
-      })
-
-  if (!(promise instanceof Promise)) {
     /**
-     * Transform.
+     * Transform synchronously.
      *
      * @param {Root} tree
      *   Tree.
@@ -75,15 +59,29 @@ export default function remarkTextr(options) {
      *   Nothing.
      */
     return function (tree) {
-      const typography = promise
       visit(tree, 'text', function (node) {
         node.value = typography.exec(node.value)
       })
     }
   }
 
+  const promise = Promise.all(
+    plugins.map(async function (fn) {
+      if (typeof fn === 'string') {
+        // Assume plugin at default.
+        /** @type {{default: TextrPlugin}} */
+        const mod = await import(fn)
+        return mod.default
+      }
+
+      return fn
+    })
+  ).then(function (list) {
+    return textr(textrOptions).use(...list)
+  })
+
   /**
-   * Transform.
+   * Transform asynchronously.
    *
    * @param {Root} tree
    *   Tree.

--- a/test.js
+++ b/test.js
@@ -78,15 +78,15 @@ test('remarkTextr', async function (t) {
     )
   })
 
-  await t.test('should support syncronous transformer', async function () {
+  t.test('should support syncronous transformer', function () {
     assert.equal(
       String(
-        await remark()
+        remark()
           .use(remarkTextr, {
             plugins: [typographicQuotes],
             options: {locale: 'ru'}
           })
-          .process('yo "there" \n')
+          .processSync('yo "there" \n')
       ),
       'yo «there»\n'
     )

--- a/test.js
+++ b/test.js
@@ -77,6 +77,20 @@ test('remarkTextr', async function (t) {
       'yo «there» …\n'
     )
   })
+
+  await t.test('should support syncronous transformer', async function () {
+    assert.equal(
+      String(
+        await remark()
+          .use(remarkTextr, {
+            plugins: [typographicQuotes],
+            options: {locale: 'ru'}
+          })
+          .process('yo "there" \n')
+      ),
+      'yo «there»\n'
+    )
+  })
 })
 
 // Textr plugin: just a function to replace triple dots to ellipses.


### PR DESCRIPTION
<!--
  Please check the needed checkboxes ([ ] -> [x]). Leave the
  comments as they are, they won’t show on GitHub.
  We are excited about pull requests, but please try to limit the scope, provide
  a general description of the changes, and remember, it’s up to you to convince
  us to land it.
-->

### Initial checklist

*   [x] I read the support docs <!-- https://github.com/remarkjs/.github/blob/main/support.md -->
*   [x] I read the contributing guide <!-- https://github.com/remarkjs/.github/blob/main/contributing.md -->
*   [x] I agree to follow the code of conduct <!-- https://github.com/remarkjs/.github/blob/main/code-of-conduct.md -->
*   [x] I searched issues and couldn’t find anything (or linked relevant results below) <!-- https://github.com/search?q=user%3Aremarkjs&type=Issues -->
*   [x] If applicable, I’ve added docs and tests

### Description of changes

I added a synchronous transformer if "options.plugins" doesn't contain a string.

I've been using [react-markdown](https://www.npmjs.com/package/react-markdown) which supports only synchronous transformers. The plugins that I used in the plugin list in my project is about 20, the only async transformer was `remark-textr` which caused a problem. I created a custom plugin in my project, but wanted to share with the community. 

I added a test and also tested in with ReactMarkdown in my project. 

I don't believe it's necessary to add this to the README since it doesn't affect users. This does not require any breaking change. 

<!--do not edit: pr-->
